### PR TITLE
Allow types to be undefined

### DIFF
--- a/.changeset/cold-poems-wait.md
+++ b/.changeset/cold-poems-wait.md
@@ -1,0 +1,5 @@
+---
+'@repka-kit/ts': patch
+---
+
+fix: allow types in package.json to be undefined

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.0.0/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "zaripych/repka" }],
+  "changelog": ["@repka-kit/changeset-changelog", { "repo": "zaripych/repka" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,5 +31,5 @@
   },
   "javascript.preferences.importModuleSpecifier": "relative",
   "typescript.preferences.importModuleSpecifier": "relative",
-  "cSpell.words": ["Pnpm", "repka"]
+  "cSpell.words": ["Pnpm", "repka", "zaripych"]
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "devDependencies": {
     "@build-tools/ts": "workspace:@repka-kit/ts@*",
-    "@changesets/changelog-github": "0.4.8",
     "@changesets/cli": "2.26.2",
+    "@repka-kit/changeset-changelog": "workspace:*",
     "@repka-kit/ts": "workspace:*",
     "husky": "8.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepare": "husky install",
     "prettify:all": "prettier './**/*.(json|js|jsx|ts|tsx|html|css|yml|yaml)' --write",
     "publish:beta": "pnpm build && pnpm publish -r --tag beta --access public",
-    "publish:snapshot": "pnpm build && pnpm publish -r --tag snapshot --access public",
+    "publish:snapshot": "publish-snapshot",
     "test": "pnpm jest",
     "test:changed": "pnpm jest --integration --changedSince=origin/main"
   },
@@ -24,6 +24,7 @@
     "@build-tools/ts": "workspace:@repka-kit/ts@*",
     "@changesets/cli": "2.26.2",
     "@repka-kit/changeset-changelog": "workspace:*",
+    "@repka-kit/scripts": "workspace:*",
     "@repka-kit/ts": "workspace:*",
     "husky": "8.0.3"
   },

--- a/packages/build-tools/ts/src/config/validatePackageJson.ts
+++ b/packages/build-tools/ts/src/config/validatePackageJson.ts
@@ -31,23 +31,11 @@ export function validatePackageJson(packageJson: PackageJson) {
       '"typings" in package.json should not be defined, use "types"'
     );
   }
-  const types = packageJson.types;
-  if (!types && (exports || packageJson.main)) {
-    throw new Error(
-      line`
-        "types" in package.json should be defined, point it to your
-        TypeScript files; ie "./src/index.ts". This would allow your
-        packages to be imported in other TypeScript packages in the
-        monorepo.
-      `
-    );
-  }
   return {
     ...packageJson,
     name,
     version,
     type,
     exports,
-    types,
   };
 }

--- a/packages/changeset/changelog/package.json
+++ b/packages/changeset/changelog/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@repka-kit/changeset-changelog",
+  "version": "0.0.0-development",
+  "private": true,
+  "type": "module",
+  "exports": "./src/bootstrap.ts",
+  "main": "./src/bootstrap.ts",
+  "types": "./src/main.ts",
+  "scripts": {
+    "lint": "repka lint"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@changesets/changelog-github": "0.4.8",
+    "@changesets/types": "5.2.1"
+  }
+}

--- a/packages/changeset/changelog/src/bootstrap.ts
+++ b/packages/changeset/changelog/src/bootstrap.ts
@@ -1,0 +1,3 @@
+require('tsx/cjs');
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+module.exports = require('./main.ts');

--- a/packages/changeset/changelog/src/main.ts
+++ b/packages/changeset/changelog/src/main.ts
@@ -1,0 +1,67 @@
+import defaultChangelogGenerator from '@changesets/changelog-github';
+import type {
+  GetDependencyReleaseLine,
+  GetReleaseLine,
+} from '@changesets/types';
+
+const getReleaseLine: GetReleaseLine = async (
+  changeset,
+  type,
+  changelogOpts
+) => {
+  try {
+    const result = await defaultChangelogGenerator.getReleaseLine(
+      changeset,
+      type,
+      changelogOpts
+    );
+    return result.replaceAll(
+      /**
+       * @note don't thank dependabot, because it doesn't care!
+       */
+      'Thanks [@dependabot](https://github.com/apps/dependabot)!',
+      ''
+    );
+  } catch (err) {
+    /*
+     * Handle the case when trying to release a snapshot locally via pnpm
+     * command, which would result in an error if a pull request is not yet
+     * created.
+     */
+    const repo =
+      typeof changelogOpts?.['repo'] === 'string'
+        ? changelogOpts['repo']
+        : 'zaripych/repka';
+
+    const commitLink = changeset.commit
+      ? `[${changeset.commit}](https://github.com/${repo}/commit/${changeset.commit})`
+      : '';
+
+    return [commitLink, changeset.summary].join(' - ');
+  }
+};
+
+const getDependencyReleaseLine: GetDependencyReleaseLine = async (
+  changesets,
+  dependenciesUpdated,
+  changelogOpts
+) => {
+  console.log({
+    changesets,
+    dependenciesUpdated,
+    changelogOpts: changelogOpts as unknown,
+  });
+  const result = await defaultChangelogGenerator.getDependencyReleaseLine(
+    changesets,
+    dependenciesUpdated,
+    changelogOpts
+  );
+  return result;
+};
+
+const pair = {
+  getReleaseLine,
+  getDependencyReleaseLine,
+};
+
+export default pair;

--- a/packages/changeset/changelog/src/main.ts
+++ b/packages/changeset/changelog/src/main.ts
@@ -37,7 +37,7 @@ const getReleaseLine: GetReleaseLine = async (
       ? `[${changeset.commit}](https://github.com/${repo}/commit/${changeset.commit})`
       : '';
 
-    return [commitLink, changeset.summary].join(' - ');
+    return ' - ' + [commitLink, changeset.summary].filter(Boolean).join(' - ');
   }
 };
 

--- a/packages/changeset/changelog/tsconfig.json
+++ b/packages/changeset/changelog/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../build-tools/ts/configs/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": ".tsc-out",
+    "tsBuildInfoFile": ".tsc-out/.tsbuildinfo",
+    "incremental": true
+  },
+  "include": ["src"]
+}

--- a/packages/utils/child-process/src/spawnOutput.ts
+++ b/packages/utils/child-process/src/spawnOutput.ts
@@ -21,8 +21,9 @@ export async function spawnOutputConditional(
   ...parameters: SpawnParameterMix<
     SpawnResultOpts & {
       /**
-       * By default will output to `stderr` when spawn result failed with an error, when
-       * status code is not zero or when `Logger.logLevel` is `debug`
+       * By default will output to `stderr` when spawn result failed with an
+       * error, when status code is not zero or when `Logger.logLevel` is
+       * `debug`
        */
       shouldOutput?: (result: SpawnResultReturn) => boolean;
     }
@@ -32,7 +33,11 @@ export async function spawnOutputConditional(
   const result = await spawnResult(child, opts);
   const shouldOutput = opts.shouldOutput ?? defaultShouldOutput;
   if (shouldOutput(result)) {
-    logger.error(result.output.join(''));
+    if ('log' in opts && !opts.log) {
+      throw new Error('Expected "log" to be defined');
+    }
+    const log = opts.log ?? ((text: string) => logger.error(text));
+    log(result.output.join(''));
   }
   if (result.error) {
     return Promise.reject(result.error);

--- a/packages/utils/markdown/package.json
+++ b/packages/utils/markdown/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@utils/markdown",
+  "version": "0.0.0-development",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./*": "./src/*.ts"
+  },
+  "scripts": {
+    "lint": "repka lint"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@jest/globals": "29.7.0",
+    "@utils/child-process": "workspace:*",
+    "dedent": "1.5.1"
+  }
+}

--- a/packages/utils/markdown/src/glowFormat.ts
+++ b/packages/utils/markdown/src/glowFormat.ts
@@ -1,0 +1,76 @@
+import { spawn } from 'node:child_process';
+
+import { spawnResult } from '@utils/child-process';
+
+import { disableGlow, isGlowEnabled } from './isGlowEnabled';
+
+function fallbackFormat(input: string) {
+  return input;
+}
+
+export const glowFormatDefaultDeps = {
+  isGlowEnabled,
+  disableGlow,
+  fallbackFormat,
+};
+
+export async function glowFormat(
+  {
+    input,
+    style = 'auto',
+    command = 'glow',
+    args,
+  }: {
+    input: string;
+    style?: 'auto' | 'dark' | 'light' | 'drakula' | 'notty';
+    command?: string;
+    args?: string[];
+  },
+  depsRaw?: Partial<typeof glowFormatDefaultDeps>
+) {
+  const deps = { ...glowFormatDefaultDeps, ...depsRaw };
+  const glowEnabled = deps.isGlowEnabled();
+  if (!glowEnabled) {
+    return deps.fallbackFormat(input);
+  }
+
+  const cols = Number.isFinite(process.stdout.columns)
+    ? process.stdout.columns
+    : 80;
+  const width = Math.max(40, Math.min(cols, 120));
+
+  const child = spawn(
+    command,
+    args ?? ['-', '-s', style, '--width', String(width), '-l'],
+    {
+      stdio: 'pipe',
+    }
+  );
+
+  child.stdin.setDefaultEncoding('utf-8');
+
+  const writeToStdin = () =>
+    new Promise<void>((res, rej) => {
+      child.stdin.write(input, (err) => {
+        if (err) {
+          rej(err);
+        } else {
+          child.stdin.end(res);
+        }
+      });
+    });
+
+  try {
+    const [result] = await Promise.all([
+      spawnResult(child, {
+        exitCodes: [0],
+        log: undefined,
+      }),
+      writeToStdin(),
+    ]);
+    return result.stdout;
+  } catch (err) {
+    deps.disableGlow();
+    return deps.fallbackFormat(input);
+  }
+}

--- a/packages/utils/markdown/src/glowPrint.ts
+++ b/packages/utils/markdown/src/glowPrint.ts
@@ -1,0 +1,95 @@
+import { spawn } from 'node:child_process';
+
+import { disableGlow, isGlowEnabled } from './isGlowEnabled';
+
+function write(text: string) {
+  process.stdout.write(text);
+}
+
+export const glowPrintDefaultDeps = {
+  isGlowEnabled,
+  disableGlow,
+  write,
+};
+
+export async function glowPrint(
+  {
+    input,
+    style = 'auto',
+    command = 'glow',
+    args,
+  }: {
+    input: string;
+    style?: 'auto' | 'dark' | 'light' | 'drakula' | 'notty';
+    command?: string;
+    args?: string[];
+  },
+  depsRaw?: Partial<typeof glowPrintDefaultDeps>
+) {
+  const deps = { ...glowPrintDefaultDeps, ...depsRaw };
+
+  function fallbackPrint(text: string) {
+    deps.write(`\n${text.replace(/^/gm, '  ')}\n\n`);
+  }
+
+  const glowEnabled = deps.isGlowEnabled();
+  if (!glowEnabled) {
+    fallbackPrint(input);
+    return;
+  }
+
+  const width = Math.max(40, Math.min(process.stdout.columns, 120));
+
+  const child = spawn(
+    command,
+    args ?? ['-', '-s', style, '--width', String(width), '-l'],
+    {
+      stdio: ['pipe', 'inherit', 'inherit'],
+    }
+  );
+
+  child.stdin.setDefaultEncoding('utf-8');
+
+  const waitToSpawn = () =>
+    new Promise<void>((res, rej) => {
+      child.once('spawn', res);
+      child.once('error', rej);
+    });
+
+  const waitToFinish = () =>
+    new Promise<void>((res, rej) => {
+      child.once('exit', (code, signal) => {
+        if (code === 0) {
+          res();
+        } else if (typeof code === 'number') {
+          rej(new Error(`Failed with ${String(code)}`));
+        } else if (typeof signal === 'string') {
+          rej(new Error(`Failed with ${String(signal)}`));
+        }
+      });
+      child.once('error', rej);
+    });
+
+  const writeToStdin = () =>
+    new Promise<void>((res, rej) => {
+      child.stdin.write(input, (err) => {
+        if (err) {
+          rej(err);
+        } else {
+          child.stdin.end(res);
+        }
+      });
+    });
+
+  const onFailure = () => {
+    deps.disableGlow();
+    fallbackPrint(input);
+  };
+
+  await Promise.all([
+    waitToSpawn().then(
+      () => writeToStdin().then(() => waitToFinish().catch(onFailure)),
+      onFailure
+    ),
+  ]);
+}

--- a/packages/utils/markdown/src/isGlowEnabled.ts
+++ b/packages/utils/markdown/src/isGlowEnabled.ts
@@ -1,0 +1,11 @@
+let glowEnabled = true;
+
+export function isGlowEnabled() {
+  const formattingDisabled =
+    process.argv.includes('--no-md-format') || !!process.env['NO_MD_FORMAT'];
+  return !formattingDisabled && glowEnabled;
+}
+
+export function disableGlow() {
+  glowEnabled = false;
+}

--- a/packages/utils/markdown/src/markdown.test.ts
+++ b/packages/utils/markdown/src/markdown.test.ts
@@ -1,0 +1,77 @@
+import { expect, it, jest } from '@jest/globals';
+
+import { glowFormat, glowFormatDefaultDeps } from './glowFormat';
+import { glowPrint, glowPrintDefaultDeps } from './glowPrint';
+import { formatMarkdown, markdown, printMarkdown } from './markdown';
+
+const noop = () => {
+  return;
+};
+
+it('should print when glow is not in the system', async () => {
+  const disableGlow = jest
+    .fn(glowPrintDefaultDeps.disableGlow)
+    .mockImplementation(noop);
+  const write = jest.fn(glowPrintDefaultDeps.write).mockImplementation(noop);
+
+  const glowPrintFn = jest.fn(glowPrint).mockImplementation((opts) =>
+    glowPrint(
+      {
+        ...opts,
+        command: 'non-existing-executable',
+      },
+      {
+        write,
+        disableGlow,
+      }
+    )
+  );
+
+  const text = markdown`
+    Hello _world_
+
+    # Header
+  `;
+
+  await printMarkdown(text, {
+    glowPrint: glowPrintFn,
+  });
+
+  expect(disableGlow).toBeCalledTimes(1);
+  expect(write).toBeCalledWith(expect.stringContaining(`Hello _world_`));
+});
+
+it('should format when glow is not in the system', async () => {
+  const disableGlow = jest
+    .fn(glowFormatDefaultDeps.disableGlow)
+    .mockImplementation(noop);
+
+  const glowFormatFn = jest.fn(glowFormat).mockImplementation((opts) =>
+    glowFormat(
+      {
+        ...opts,
+        command: 'non-existing-executable',
+      },
+      {
+        disableGlow,
+      }
+    )
+  );
+
+  expect(
+    await formatMarkdown(
+      markdown`
+        Hello _world_
+
+        # Header
+      `,
+      {
+        glowFormat: glowFormatFn,
+      }
+    )
+  ).toBe(`Hello _world_
+
+# Header`);
+
+  expect(disableGlow).toBeCalledTimes(1);
+});

--- a/packages/utils/markdown/src/markdown.ts
+++ b/packages/utils/markdown/src/markdown.ts
@@ -1,0 +1,53 @@
+import dedent from 'dedent';
+import { format as formatText } from 'util';
+
+import { glowFormat } from './glowFormat';
+import { glowPrint } from './glowPrint';
+
+export function markdown(template: string, ...values: unknown[]): string;
+export function markdown(
+  template: TemplateStringsArray,
+  ...values: unknown[]
+): string;
+export function markdown(
+  template: TemplateStringsArray | string,
+  ...values: unknown[]
+): string {
+  if (typeof template === 'string') {
+    return formatText(dedent(template), ...values);
+  }
+  return formatText(
+    dedent(
+      template
+        .map((str, i) => {
+          if (i < values.length) {
+            return str + '%s';
+          } else {
+            return str;
+          }
+        })
+        .join('')
+    ),
+    ...values
+  );
+}
+
+export async function formatMarkdown(input: string, deps = { glowFormat }) {
+  return deps.glowFormat({
+    input: input
+      .replace(/^\s*/g, '')
+      .replace(/^\n/g, '')
+      .replace(/\n$/g, '')
+      .trim(),
+  });
+}
+
+export async function printMarkdown(input: string, deps = { glowPrint }) {
+  await deps.glowPrint({
+    input: input
+      .replace(/^\s*/g, '')
+      .replace(/^\n/g, '')
+      .replace(/\n$/g, '')
+      .trim(),
+  });
+}

--- a/packages/utils/markdown/tsconfig.json
+++ b/packages/utils/markdown/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../build-tools/ts/configs/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": ".tsc-out",
+    "tsBuildInfoFile": ".tsc-out/.tsbuildinfo",
+    "incremental": true
+  },
+  "include": ["src"]
+}

--- a/packages/utils/scripts/package.json
+++ b/packages/utils/scripts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@repka-kit/scripts",
+  "version": "0.0.0-development",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "publish-snapshot": "./src/bin/publish-snapshot.ts"
+  },
+  "scripts": {
+    "lint": "repka lint"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@utils/child-process": "workspace:*",
+    "@utils/text": "workspace:*",
+    "@utils/ts": "workspace:*"
+  }
+}

--- a/packages/utils/scripts/src/bin/publish-snapshot.ts
+++ b/packages/utils/scripts/src/bin/publish-snapshot.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env tsx
+import { spawnOutputConditional, spawnToPromise } from '@utils/child-process';
+import { line } from '@utils/text';
+
+async function run() {
+  const dryRun = !process.argv.includes('--no-dry-run');
+
+  const spawn = async (command: string, args: string[]) => {
+    return await spawnOutputConditional(command, args, {
+      stdio: 'pipe',
+      exitCodes: [0],
+    });
+  };
+
+  await spawn('git', ['add', '.']);
+
+  console.log(`creating a git stash with changes:\n`);
+
+  const stashResult = await spawn('git', ['stash', '-k', '-u', '-m', 'backup']);
+  try {
+    await spawnOutputConditional(
+      'pnpm',
+      ['changeset', 'version', '--snapshot', 'snap'],
+      {
+        stdio: 'pipe',
+        exitCodes: [0],
+        env: {
+          ...process.env,
+          CHANGESETS_VERSION: '1',
+        },
+      }
+    );
+
+    console.log(`git status before publish:\n`);
+
+    await spawnToPromise('git', ['status'], {
+      stdio: 'inherit',
+      exitCodes: [0],
+    });
+
+    console.log();
+
+    await spawnToPromise(
+      'git',
+      ['--no-pager', 'diff', '--', '**/CHANGELOG.md'],
+      {
+        stdio: 'inherit',
+        exitCodes: [0],
+      }
+    );
+
+    console.log();
+
+    console.log(`building...\n`);
+
+    await spawn('pnpm', ['-r', '/build:tools|declarations/']);
+
+    console.log(`publishing ... ${dryRun ? '(dry-run)' : ''}\n`);
+
+    await spawnToPromise(
+      'pnpm',
+      [
+        'publish',
+        '-r',
+        '--tag',
+        'snap',
+        '--access',
+        'public',
+        '--no-git-checks',
+        dryRun ? '--dry-run' : '',
+      ],
+      {
+        stdio: 'inherit',
+        exitCodes: [0],
+      }
+    );
+
+    if (dryRun) {
+      console.log();
+      console.log(
+        line`
+          successfully published in dry-run mode, pass --no-dry-run to
+          publish for real
+        `
+      );
+      console.log();
+    }
+  } finally {
+    await spawn('git', ['reset', '--hard']);
+    if (!stashResult.stdout.includes('No local changes to save')) {
+      await spawn('git', ['stash', 'pop']);
+    }
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+});

--- a/packages/utils/scripts/tsconfig.json
+++ b/packages/utils/scripts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../build-tools/ts/configs/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": ".tsc-out",
+    "tsBuildInfoFile": ".tsc-out/.tsbuildinfo",
+    "incremental": true
+  },
+  "include": ["src"]
+}

--- a/packages/utils/text/package.json
+++ b/packages/utils/text/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@utils/text",
+  "version": "0.0.0-development",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "repka lint"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@jest/globals": "29.7.0",
+    "@utils/ts": "workspace:*"
+  }
+}

--- a/packages/utils/text/src/format.test.ts
+++ b/packages/utils/text/src/format.test.ts
@@ -1,0 +1,257 @@
+import { expect, it } from '@jest/globals';
+import { format as formatText } from 'util';
+
+import { format } from './format';
+
+export function md(
+  template: TemplateStringsArray,
+  ...values: unknown[]
+): string {
+  return formatText(
+    template
+      .map((str, i) => {
+        if (i < values.length) {
+          return str + '%s';
+        } else {
+          return str;
+        }
+      })
+      .join('')
+      .replaceAll(/\n[ ]+/g, '\n')
+      .trim(),
+    ...values
+  );
+}
+
+it('looks readable when parameters are inline', () => {
+  const result = format(
+    md`
+      # Preface
+
+      This is a test for %var1% and %var2%.
+
+      # Details
+
+      We want our inline markdown to be formatted by prettier. This ensures that
+      the markdown is easy to read and maintain - both in the code editor or on
+      GitHub.
+
+      At the same time we do not want template literal vars to break the
+      formatting. Tagged template literal variables are a blunder to read when
+      formatted by prettier, so we want to avoid that.
+
+      Therefore, we use a custom substitute function that replaces placeholders
+      with values and rely on prettier to format the markdown.
+
+      In addition to that, our markdown is also de-dented using the dedent npm
+      module.
+
+      The choice of the \`%\` prefix is to ensure that the markdown is
+      compatible with TypeScript code blocks.
+
+      ~~~ts
+      %example%
+      ~~~
+
+      If the code wasn't de-dented, it would have to look like the expectation
+      below.
+    `,
+    {
+      var1: 'readability',
+      var2: 'clarity',
+      example: 'console.log("Hello, World!");',
+    }
+  );
+
+  expect(result).toBe(`# Preface
+
+This is a test for readability and clarity.
+
+# Details
+
+We want our inline markdown to be formatted by prettier. This ensures that
+the markdown is easy to read and maintain - both in the code editor or on
+GitHub.
+
+At the same time we do not want template literal vars to break the
+formatting. Tagged template literal variables are a blunder to read when
+formatted by prettier, so we want to avoid that.
+
+Therefore, we use a custom substitute function that replaces placeholders
+with values and rely on prettier to format the markdown.
+
+In addition to that, our markdown is also de-dented using the dedent npm
+module.
+
+The choice of the \`%\` prefix is to ensure that the markdown is
+compatible with TypeScript code blocks.
+
+~~~ts
+console.log("Hello, World!");
+~~~
+
+If the code wasn't de-dented, it would have to look like the expectation
+below.`);
+});
+
+it('works when variables are empty strings', () => {
+  const result = format(
+    md`
+      # Empty variables handling
+
+      Often we want to skip a variable if it is empty. This is useful when the
+      variable is optional %empty%.
+
+      In these cases we can simply use the \`||\` operator to provide a default
+      value but that might lead to additional empty lines. This is not a problem
+      with most markdown renderers.
+
+      Well, a model might add extra meaning to it. While that's unlikely, I've
+      decided to add an option to remove extra empty lines and spaces. This
+      should make the prompts we send to the model more readable. %empty%
+
+      %empty%
+
+      There is an extra parameter that allows us to remove extra empty lines
+      before and after the substitution. %empty% This should remove the extra
+      empty lines and spaces but not too many %empty%.
+
+      %empty% We cannot do much about cases where the variable is at the start
+      of the sentence like this, so the "We" could remain uncapitalized.
+    `,
+    {
+      empty: '',
+    },
+    {
+      trimEmptyLines: true,
+      trimSpaces: true,
+    }
+  );
+
+  expect(result).toBe(`# Empty variables handling
+
+Often we want to skip a variable if it is empty. This is useful when the
+variable is optional.
+
+In these cases we can simply use the \`||\` operator to provide a default
+value but that might lead to additional empty lines. This is not a problem
+with most markdown renderers.
+
+Well, a model might add extra meaning to it. While that's unlikely, I've
+decided to add an option to remove extra empty lines and spaces. This
+should make the prompts we send to the model more readable.
+
+There is an extra parameter that allows us to remove extra empty lines
+before and after the substitution. This should remove the extra
+empty lines and spaces but not too many.
+
+We cannot do much about cases where the variable is at the start
+of the sentence like this, so the "We" could remain uncapitalized.`);
+});
+
+it('should substitute when the text around placeholder is empty', () => {
+  const text = '%name%';
+  const values = { name: 'World' };
+
+  const result = format(text, values);
+
+  expect(result).toBe('World');
+});
+
+it('should substitute when the text around placeholder is whitespace', () => {
+  const text = ' %name% ';
+  const values = { name: 'World' };
+
+  const result = format(text, values);
+
+  expect(result).toBe(' World ');
+});
+
+it('should substitute placeholder with given values', () => {
+  const text = 'Hello, %name%!';
+  const values = { name: 'World' };
+
+  const result = format(text, values);
+
+  expect(result).toBe('Hello, World!');
+});
+
+it('should not change the text for empty placeholders', () => {
+  const text = 'Hello, %%!';
+
+  const result = format(text, {});
+
+  expect(result).toBe('Hello, %%!');
+});
+
+it('should not change the text for placeholders with spaces', () => {
+  const text = '- % % -';
+
+  const result = format(text, {});
+
+  expect(result).toBe('- % % -');
+});
+
+it('should not change the text for placeholders with punctuation', () => {
+  const text = '- %-% -';
+
+  const result = format(text, {});
+
+  expect(result).toBe('- %-% -');
+});
+
+it('should throw an error if value for substitute field does not exist', () => {
+  const text = 'Hello, %name%! I am %age% years old.';
+  const values = { name: 'World' };
+
+  expect(() => {
+    format(text, values);
+  }).toThrow('value of age is missing');
+});
+
+it('should substitute placeholder with different prefix character', () => {
+  const text = 'Hello, *name*!';
+  const values = { name: 'World' };
+  /**
+   * @note changing prefix and suffix to '*'
+   */
+  const options = { prefix: '*' };
+
+  const result = format(text, values, options);
+
+  expect(result).toBe('Hello, World!');
+});
+
+it('should throw an error when substitute field is not present in the values object', () => {
+  const text = 'Hello, %name%!';
+  /**
+   * @note name is present, but age is not in the values object
+   */
+  const values = { age: '20' };
+
+  expect(() => {
+    format(text, values);
+  }).toThrow('value of name is missing');
+});
+
+it('should handle field value not being a string', () => {
+  const text = 'Hello, %name%, %age%!';
+  /**
+   * @note age is not a string in the values object
+   */
+  const values = { name: 'World', age: 20 };
+
+  expect(() => {
+    // @ts-expect-error age is not a string
+    format(text, values);
+  }).toThrow('value of age is not a string');
+});
+
+it('should return the same string when there are no placeholders to substitute', () => {
+  const text = 'Hello, World!';
+  const values = {};
+
+  const result = format(text, values);
+
+  expect(result).toBe('Hello, World!');
+});

--- a/packages/utils/text/src/format.ts
+++ b/packages/utils/text/src/format.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert';
+
+import { escapeRegExp } from '@utils/ts';
+
+import { replaceNewlinesWithSpaces } from './line';
+
+export function format(
+  text: string,
+  values: Record<string, string>,
+  opts?: {
+    prefix?: string;
+    suffix?: string;
+    trimEmptyLines?: boolean;
+    trimSpaces?: boolean;
+    singleLine?: boolean;
+  }
+) {
+  const prefix = opts?.prefix || '%';
+  const suffix = opts?.suffix || prefix;
+  const trimEmptyLines = opts?.trimEmptyLines ?? true;
+  const trimSpaces = opts?.trimSpaces ?? true;
+
+  const regexp = new RegExp(
+    escapeRegExp(prefix) + '(\\w(\\w|\\d)*)' + escapeRegExp(suffix),
+    'i'
+  );
+
+  let result = text;
+  let element = regexp.exec(text);
+
+  while (element) {
+    assert(typeof element.index === 'number', 'element.index is undefined');
+
+    const key = element[1];
+    assert(key, `var name at ${element.index} is undefined`);
+
+    assert(key in values, `value of ${key} is missing`);
+
+    const value = values[key];
+    assert(typeof value === 'string', `value of ${key} is not a string`);
+
+    const before = result.substring(0, element.index);
+    const after = result.substring(element.index + element[0].length);
+
+    if (value === '' && (trimEmptyLines || trimSpaces)) {
+      let beforeWhitespace = before.match(/\s*$/)?.[0] ?? '';
+      let afterWhitespace = after.match(/^\s*/)?.[0] ?? '';
+
+      if (trimEmptyLines) {
+        beforeWhitespace = beforeWhitespace.replaceAll(
+          new RegExp(escapeRegExp('\n') + '+', 'g'),
+          afterWhitespace.includes('\n') ? '\n' : '\n'.repeat(2)
+        );
+        afterWhitespace = afterWhitespace.replaceAll(
+          new RegExp(escapeRegExp('\n') + '+', 'g'),
+          '\n'
+        );
+      }
+
+      if (trimSpaces) {
+        beforeWhitespace = beforeWhitespace.replaceAll(
+          new RegExp(escapeRegExp(' ') + '+', 'g'),
+          ' '
+        );
+        afterWhitespace = afterWhitespace.replaceAll(
+          new RegExp(escapeRegExp(' ') + '+', 'g'),
+          beforeWhitespace.length > 0 ? '' : ' '
+        );
+
+        // handle punctuation at the start of the "after" string
+        if (/^\p{P}+/gu.test(after.trimStart())) {
+          beforeWhitespace = '';
+        }
+      }
+
+      result =
+        before.trimEnd() +
+        beforeWhitespace +
+        afterWhitespace +
+        after.trimStart();
+    } else {
+      result = before + value + after;
+    }
+
+    element = regexp.exec(result);
+  }
+
+  if (opts?.singleLine ?? false) {
+    return replaceNewlinesWithSpaces(result);
+  } else {
+    return result;
+  }
+}

--- a/packages/utils/text/src/index.ts
+++ b/packages/utils/text/src/index.ts
@@ -1,0 +1,2 @@
+export * from './format';
+export * from './line';

--- a/packages/utils/text/src/line.test.ts
+++ b/packages/utils/text/src/line.test.ts
@@ -1,0 +1,22 @@
+import { expect, it } from '@jest/globals';
+
+import { line } from './line';
+
+it('replaces newlines with spaces', () => {
+  expect(line`
+    This is an example of how the line function operates and it is
+    intended to be used for parameters passed as Error messages or
+    places where a single unbroken line is required.
+  `).toBe(
+    'This is an example of how the line function operates and it is intended to be used for parameters passed as Error messages or places where a single unbroken line is required.'
+  );
+});
+
+it('should remove line breaks and their surrounding indent', () => {
+  expect(line`
+    This is first line,
+
+      the second,
+      third line.
+  `).toBe(`This is first line, the second, third line.`);
+});

--- a/packages/utils/text/src/line.ts
+++ b/packages/utils/text/src/line.ts
@@ -1,0 +1,23 @@
+import { format } from 'node:util';
+
+export function replaceNewlinesWithSpaces(text: string): string {
+  return text.replaceAll(/\s*\n\s*/g, ' ').trim();
+}
+
+export function line(template: string, ...values: unknown[]): string;
+export function line(
+  template: TemplateStringsArray,
+  ...values: unknown[]
+): string;
+export function line(
+  template: string | TemplateStringsArray,
+  ...values: unknown[]
+) {
+  if (typeof template === 'string') {
+    if (values.length === 0) {
+      return replaceNewlinesWithSpaces(template);
+    }
+    return replaceNewlinesWithSpaces(format(template, ...values));
+  }
+  return replaceNewlinesWithSpaces(String.raw({ raw: template }, ...values));
+}

--- a/packages/utils/text/src/line.ts
+++ b/packages/utils/text/src/line.ts
@@ -1,7 +1,7 @@
 import { format } from 'node:util';
 
 export function replaceNewlinesWithSpaces(text: string): string {
-  return text.replaceAll(/\s*\n\s*/g, ' ').trim();
+  return text.replaceAll(/[ \t]*[\n]+[ \t]*/g, ' ').trim();
 }
 
 export function line(template: string, ...values: unknown[]): string;

--- a/packages/utils/text/tsconfig.json
+++ b/packages/utils/text/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../build-tools/ts/configs/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": ".tsc-out",
+    "tsBuildInfoFile": ".tsc-out/.tsbuildinfo",
+    "incremental": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,12 @@ importers:
       '@build-tools/ts':
         specifier: workspace:@repka-kit/ts@*
         version: link:packages/build-tools/ts
-      '@changesets/changelog-github':
-        specifier: 0.4.8
-        version: 0.4.8
       '@changesets/cli':
         specifier: 2.26.2
         version: 2.26.2
+      '@repka-kit/changeset-changelog':
+        specifier: workspace:*
+        version: link:packages/changeset/changelog
       '@repka-kit/ts':
         specifier: workspace:*
         version: link:packages/build-tools/ts
@@ -194,6 +194,15 @@ importers:
         specifier: 3.10.0
         version: 3.10.0
     publishDirectory: dist
+
+  packages/changeset/changelog:
+    devDependencies:
+      '@changesets/changelog-github':
+        specifier: 0.4.8
+        version: 0.4.8
+      '@changesets/types':
+        specifier: 5.2.1
+        version: 5.2.1
 
   packages/playground/bin-only:
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@repka-kit/changeset-changelog':
         specifier: workspace:*
         version: link:packages/changeset/changelog
+      '@repka-kit/scripts':
+        specifier: workspace:*
+        version: link:packages/utils/scripts
       '@repka-kit/ts':
         specifier: workspace:*
         version: link:packages/build-tools/ts
@@ -271,6 +274,39 @@ importers:
         version: 3.10.0
 
   packages/utils/logger:
+    devDependencies:
+      '@jest/globals':
+        specifier: 29.7.0
+        version: 29.7.0
+      '@utils/ts':
+        specifier: workspace:*
+        version: link:../ts
+
+  packages/utils/markdown:
+    devDependencies:
+      '@jest/globals':
+        specifier: 29.7.0
+        version: 29.7.0
+      '@utils/child-process':
+        specifier: workspace:*
+        version: link:../child-process
+      dedent:
+        specifier: 1.5.1
+        version: 1.5.1
+
+  packages/utils/scripts:
+    devDependencies:
+      '@utils/child-process':
+        specifier: workspace:*
+        version: link:../child-process
+      '@utils/text':
+        specifier: workspace:*
+        version: link:../text
+      '@utils/ts':
+        specifier: workspace:*
+        version: link:../ts
+
+  packages/utils/text:
     devDependencies:
       '@jest/globals':
         specifier: 29.7.0
@@ -2693,7 +2729,6 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
-    dev: false
 
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}


### PR DESCRIPTION
The `package.json` `"types"` can be undefined really as `tsc` just uses the `default` entry in `exports` and looks up `.d.ts` files next to the entries automatically.

This also includes some maintainance changes to improve changesets changelog output.

This also introduces a dev-time cli to allow publishing snapshots from local environment.